### PR TITLE
Corrected function param naming issue with redirect to controller

### DIFF
--- a/core/abstracts/Controller.php
+++ b/core/abstracts/Controller.php
@@ -18,9 +18,9 @@ abstract class Controller implements \qck\core\interfaces\Controller
     return $this->proxyRun();
   }
 
-  function redirect($ControllerFqcn, $args = array ())
+  function redirect($ControllerClassname, $args = array ())
   {
-    header("Location: ".$this->getAppConfig()->mkLink( $ControllerFqcn, $args ));
+    header("Location: ".$this->getAppConfig()->mkLink( $ControllerClassname, $args ));
     return null;
   }
   

--- a/ext/Session.php
+++ b/ext/Session.php
@@ -24,7 +24,7 @@ class Session implements interfaces\Session
   public function getUsername()
   {
     $this->start();
-    return isset( $_SESSION[ self::USER_ID_KEY ] ) ? isset( $_SESSION[ self::USER_ID_KEY ] ) : null;
+    return isset( $_SESSION[ self::USER_ID_KEY ] ) ? $_SESSION[ self::USER_ID_KEY ] : null;
   }
 
   public function setUsername( $id )


### PR DESCRIPTION
The function mkLink has the $ControllerClassName as parameter instead of the Fqcn.